### PR TITLE
Fix closing exec connections on che task SIGINT termination.

### DIFF
--- a/dockerfiles/ci/Dockerfile
+++ b/dockerfiles/ci/Dockerfile
@@ -12,7 +12,7 @@
 # Dockerfile defines che-machine-exec production image eclipse/che-machine-exec-dev
 #
 
-FROM golang:1.10.3-alpine as builder
+FROM golang:1.10.7-alpine as builder
 WORKDIR /go/src/github.com/eclipse/che-machine-exec/
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -a -installsuffix cgo -o che-machine-exec .
@@ -20,9 +20,8 @@ RUN apk add --no-cache ca-certificates
 
 RUN adduser -D -g '' unprivilegeduser
 
-FROM scratch
+FROM busybox
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /go/src/github.com/eclipse/che-machine-exec/che-machine-exec /go/bin/che-machine-exec
 
 USER unprivilegeduser

--- a/dockerfiles/ci/Dockerfile
+++ b/dockerfiles/ci/Dockerfile
@@ -22,6 +22,7 @@ RUN adduser -D -g '' unprivilegeduser
 
 FROM busybox
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /go/src/github.com/eclipse/che-machine-exec/che-machine-exec /go/bin/che-machine-exec
 
 USER unprivilegeduser

--- a/dockerfiles/ci/Dockerfile
+++ b/dockerfiles/ci/Dockerfile
@@ -12,7 +12,7 @@
 # Dockerfile defines che-machine-exec production image eclipse/che-machine-exec-dev
 #
 
-FROM golang:1.10.7-alpine as builder
+FROM golang:1.10.3-alpine as builder
 WORKDIR /go/src/github.com/eclipse/che-machine-exec/
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -a -installsuffix cgo -o che-machine-exec .

--- a/rhel.Dockerfile
+++ b/rhel.Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 RUN adduser unprivilegeduser && \
     CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -a -installsuffix cgo -o che-machine-exec .
 
-FROM scratch
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /go/src/github.com/eclipse/che-machine-exec/che-machine-exec /go/bin/che-machine-exec
 USER unprivilegeduser


### PR DESCRIPTION
## Referenced issue: 
https://github.com/eclipse/che/issues/14887

Fix closing exec connections on  che task SIGINT termination.

Proposed changes: change image from `scratch` to `busybox`. Image will be bigger on 1.2Mb (26.7Mb against 25.5), but issue won't reproduces with this image. 
P.S.: Alpine 3.10.2 works fine too, but image is bigger.

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>