### PR TITLE
Add absent /tmp folder in the exec image to fix task SIGINT termination

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,18 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -a -installsuffix cgo -o che-machine-exec .
 RUN apk add --no-cache ca-certificates
 
-RUN adduser -D -g '' unprivilegeduser
+RUN adduser -D -g '' unprivilegeduser && \
+    mkdir -p /rootfs/tmp /rootfs/etc /rootfs/etc/ssl/certs /rootfs/go/bin && \
+    # In the `scratch` you can't use Dockerfile#RUN, because there is no shell and no standard commands (mkdir and so on).
+    # That's why prepare absent `/tmp` folder for scratch image 
+    chmod 1777 /rootfs/tmp && \
+    cp -rf /etc/passwd /rootfs/etc && \
+    cp -rf /etc/ssl/certs/ca-certificates.crt /rootfs/etc/ssl/certs && \
+    cp -rf /go/src/github.com/eclipse/che-machine-exec/che-machine-exec /rootfs/go/bin
 
 FROM scratch
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder /go/src/github.com/eclipse/che-machine-exec/che-machine-exec /go/bin/che-machine-exec
+
+COPY --from=builder /rootfs /
 
 USER unprivilegeduser
 


### PR DESCRIPTION
### What does this PR do?
Add absent /tmp folder in the exec image to fix task SIGINT termination

### Referenced issue:
https://github.com/eclipse/che/issues/14887

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>
