### PR TITLE
Fix machine exec build

### DIFF
--- a/.github/workflows/gh_actions_pr.yaml
+++ b/.github/workflows/gh_actions_pr.yaml
@@ -15,19 +15,6 @@ on: pull_request
 jobs:
   build:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.default == false }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [linux/amd64]
-        default: [true]
-        include:
-          - platform: linux/arm64
-            default: false
-          - platform: linux/ppc64le
-            default: false
-          - platform: linux/s390x
-            default: false
     steps:
     - name: Checkout che-machine-exec source code
       uses: actions/checkout@v2
@@ -39,6 +26,6 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         file: build/dockerfiles/Dockerfile
-        platforms: ${{ matrix.platform }}
+        platforms: linux/amd64,linux/ppc64le,linux/arm64
         push: false
         tags: quay.io/eclipse/che-machine-exec:pr-check

--- a/.github/workflows/gh_actions_push.yaml
+++ b/.github/workflows/gh_actions_push.yaml
@@ -17,17 +17,6 @@ on:
 jobs:
   build-push:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.default == false }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [linux/amd64]
-        default: [true]
-        include:
-          - platform: linux/arm64
-            default: false
-          - platform: linux/ppc64le
-            default: false
     steps:
     - name: Checkout che-machine-exec source code
       uses: actions/checkout@v2
@@ -49,7 +38,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         file: build/dockerfiles/Dockerfile
-        platforms: ${{ matrix.platform }}
+        platforms: linux/amd64,linux/ppc64le,linux/arm64
         push: true
         tags: |
           quay.io/eclipse/che-machine-exec:nightly


### PR DESCRIPTION
$ docker run --rm -it quay.io/eclipse/che-machine-exec:nightly                                                                                                                                                              Unable to find image 'quay.io/eclipse/che-machine-exec:nightly' locally
Digest: sha256:c25227a7dc501638e2108797ae634fdc86b2ddd9eae3bdd09d2507295ba60ab7
Status: Downloaded newer image for quay.io/eclipse/che-machine-exec:nightly
WARNING: The requested image's platform (linux/ppc64le) does not match the detected host platform (linux/amd64) and no specific platform was requested
INFO[0000] Default 'info' log level is applied

Signed-off-by: Flavius Lacatusu <flacatus@redhat.com>