### PR TITLE
removing env.Name check to adapt to che sidecar env var removal

### DIFF
--- a/activity/manager.go
+++ b/activity/manager.go
@@ -69,7 +69,7 @@ func New(idleTimeout, stopRetryPeriod time.Duration) (Manager, error) {
 	if !isFound {
 		workspaceName, isFound = os.LookupEnv("DEVWORKSPACE_NAME")
 		if !isFound {
-			return nil, errors.New("CHE_WORKSPACE_NAME env or DEVWORKSPACE_NAME env must be set for activity manager works correctly")
+			return nil, errors.New("CHE_WORKSPACE_NAME or DEVWORKSPACE_NAME environment variables must be set for activity manager to work correctly")
 		}
 	}
 

--- a/activity/manager.go
+++ b/activity/manager.go
@@ -67,7 +67,10 @@ func New(idleTimeout, stopRetryPeriod time.Duration) (Manager, error) {
 
 	workspaceName, isFound := os.LookupEnv("CHE_WORKSPACE_NAME")
 	if !isFound {
-		return nil, errors.New("CHE_WORKSPACE_NAME env must be set for activity manager works correctly")
+		workspaceName, isFound = os.LookupEnv("DEVWORKSPACE_NAME")
+		if !isFound {
+			return nil, errors.New("CHE_WORKSPACE_NAME env or DEVWORKSPACE_NAME env must be set for activity manager works correctly")
+		}
 	}
 
 	return managerImpl{

--- a/filter/kubernetes_filter.go
+++ b/filter/kubernetes_filter.go
@@ -55,11 +55,7 @@ func (filter *KubernetesContainerFilter) GetContainerList() (containersInfo []*m
 
 	for _, pod := range pods.Items {
 		for _, container := range pod.Spec.Containers {
-			for _, env := range container.Env {
-				if env.Name == MachineNameEnvVar {
-					containersInfo = append(containersInfo, &model.ContainerInfo{ContainerName: container.Name, PodName: pod.Name})
-				}
-			}
+			containersInfo = append(containersInfo, &model.ContainerInfo{ContainerName: container.Name, PodName: pod.Name})
 		}
 	}
 
@@ -120,6 +116,10 @@ func findContainerName(pod v1.Pod, machineName string) string {
 			if env.Name == MachineNameEnvVar && env.Value == machineName {
 				return container.Name
 			}
+		}
+		// ^ Che specific logic failed, try devworkspace one
+		if container.Name == machineName {
+			return container.Name
 		}
 	}
 	return ""


### PR DESCRIPTION
Removing check for env.Name to adapt to che sidecar removal from devworkspace operator.

Issue Reference: https://github.com/devfile/devworkspace-operator/issues/344
Related to: https://github.com/devfile/devworkspace-operator/pull/347