### PR TITLE
Remove `CODECOV_TOKEN` from GitHub action

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -20,8 +20,6 @@ jobs:
         with:
           persist-credentials: false
       - name: Submit code coverage results
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
          echo "" > coverage.txt
          export CHE_WORKSPACE_ID=test_id; go test -v ./... -coverprofile coverage.txt


### PR DESCRIPTION
### What does this PR do

Removes CODECOV_TOKEN from GitHub action.
It isn't needed [1] and it is compromised [2]

[1] https://docs.codecov.io/docs/about-the-codecov-bash-uploader#upload-token
[2] https://about.codecov.io/security-update/

