### PR TITLE
Add docker.io to FROM container name

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -11,7 +11,7 @@
 #
 # Dockerfile defines che-machine-exec production image eclipse/che-machine-exec-dev
 #
-FROM golang:1.12.8-alpine as go_builder
+FROM docker.io/golang:1.12.8-alpine as go_builder
 
 ENV USER=machine-exec
 ENV UID=12345
@@ -37,7 +37,7 @@ WORKDIR /che-machine-exec/
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=vendor -a -ldflags '-w -s' -a -installsuffix cgo -o /go/bin/che-machine-exec .
 
-FROM node:10.16-alpine as cloud_shell_builder
+FROM docker.io/node:10.16-alpine as cloud_shell_builder
 COPY --from=go_builder /che-machine-exec/cloud-shell cloud-shell-src
 WORKDIR cloud-shell-src
 RUN yarn && \


### PR DESCRIPTION
Sometimes if Dockerfile don't have in FROM the registry url, using podman is hard to automatize build images. Podman Terminal on building:
![image](https://user-images.githubusercontent.com/59865209/117071346-49e8e500-ad2f-11eb-8f09-15d553dedad4.png)
Signed-off-by: Flavius Lacatusu <flacatus@redhat.com>