### PR TITLE
feat(sleep): Add sleep utility to make it compliant with image puller

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2019 Red Hat, Inc.
+# Copyright (c) 2012-2021 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -11,6 +11,10 @@
 #
 # Dockerfile defines che-machine-exec production image eclipse/che-machine-exec-dev
 #
+
+# https://quay.io/repository/eclipse/kubernetes-image-puller?tab=tags
+FROM quay.io/eclipse/kubernetes-image-puller:e28a7fb as k8s-image-puller
+
 FROM docker.io/golang:1.12.8-alpine as go_builder
 
 ENV USER=machine-exec
@@ -49,10 +53,10 @@ FROM scratch
 COPY --from=go_builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=go_builder /etc/passwd /etc/passwd
 COPY --from=go_builder /etc/group /etc/group
-COPY --from=go_builder /bin/sleep /bin/sleep
 USER machine-exec
 
 COPY --from=go_builder /go/bin/che-machine-exec /go/bin/che-machine-exec
 COPY --from=cloud_shell_builder /app /cloud-shell
+COPY --from=k8s-image-puller /bin/sleep /bin/sleep
 
 ENTRYPOINT ["/go/bin/che-machine-exec", "--static", "/cloud-shell"]

--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -27,9 +27,10 @@ RUN adduser unprivilegeduser && \
 FROM scratch
 
 COPY --from=builder /rootfs /
-# Arch-specific version of sleep binary can be found in quay.io/repository/crw/imagepuller-rhel8:2.9-4 (or newer)
-# see https://github.com/redhat-developer/codeready-workspaces-deprecated/blob/crw-2-rhel-8/sleep/build.sh to fetch single-arch locally
-# see https://main-jenkins-csb-crwqe.apps.ocp4.prod.psi.redhat.com/job/CRW_CI/job/crw-deprecated_2.x/ to build multi-arch
+# Arch-specific version of sleep binary can be found in quay.io/crw/imagepuller-rhel8 as of 2.9-4 (or newer tag)
+# see https://github.com/redhat-developer/codeready-workspaces-deprecated/tree/crw-2-rhel-8/sleep/build.sh to fetch single-arch locally
+# see https://main-jenkins-csb-crwqe.apps.ocp4.prod.psi.redhat.com/job/CRW_CI/job/crw-deprecated_2.x/ to build multi-arch tarballs that can
+# then be used in Brew
 COPY --from=builder /che-machine-exec/sleep /bin/sleep
 
 USER unprivilegeduser

--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2021 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -8,6 +8,9 @@
 # Contributors:
 #   Red Hat, Inc. - initial API and implementation
 #
+
+# https://quay.io/repository/eclipse/kubernetes-image-puller?tab=tags
+FROM quay.io/eclipse/kubernetes-image-puller:e28a7fb as k8s-image-puller
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/rhel8/go-toolset
 FROM registry.redhat.io/rhel8/go-toolset:1.14.12-5 as builder
@@ -27,7 +30,7 @@ RUN adduser unprivilegeduser && \
 FROM scratch
 
 COPY --from=builder /rootfs /
-COPY --from=builder /usr/bin/sleep /usr/bin/sleep
+COPY --from=k8s-image-puller /bin/sleep /bin/sleep
 
 USER unprivilegeduser
 ENTRYPOINT ["/go/bin/che-machine-exec"]

--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -9,9 +9,6 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-# https://quay.io/repository/eclipse/kubernetes-image-puller?tab=tags
-FROM quay.io/eclipse/kubernetes-image-puller:e28a7fb as k8s-image-puller
-
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/rhel8/go-toolset
 FROM registry.redhat.io/rhel8/go-toolset:1.14.12-5 as builder
 ENV GOPATH=/go/
@@ -30,7 +27,10 @@ RUN adduser unprivilegeduser && \
 FROM scratch
 
 COPY --from=builder /rootfs /
-COPY --from=k8s-image-puller /bin/sleep /bin/sleep
+# Arch-specific version of sleep binary can be found in quay.io/repository/crw/imagepuller-rhel8:2.9-4 (or newer)
+# see https://github.com/redhat-developer/codeready-workspaces-deprecated/blob/crw-2-rhel-8/sleep/build.sh to fetch single-arch locally
+# see https://main-jenkins-csb-crwqe.apps.ocp4.prod.psi.redhat.com/job/CRW_CI/job/crw-deprecated_2.x/ to build multi-arch
+COPY --from=builder /che-machine-exec/sleep /bin/sleep
 
 USER unprivilegeduser
 ENTRYPOINT ["/go/bin/che-machine-exec"]

--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -9,8 +9,8 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/rhel8/go-toolset
-FROM registry.redhat.io/rhel8/go-toolset:1.14.12-5 as builder
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/go-toolset
+FROM registry.redhat.io/ubi8/go-toolset:1.14.12-17.1618436992 as builder
 ENV GOPATH=/go/
 USER root
 WORKDIR /che-machine-exec/


### PR DESCRIPTION
Image puller is executing `sleep` command but scratch images don't have this utility

Adds the `self-contained` sleep utility to make it working

related to https://github.com/eclipse/che/issues/19755

Change-Id: Ic91decb30d5f7cc66f01e1cdd18a8b5fe3c7c4fe
Signed-off-by: Florent Benoit <fbenoit@redhat.com>