### PR TITLE
feat: read timeouts from env variables, implement run timeout

### DIFF
--- a/api/rest/activity.go
+++ b/api/rest/activity.go
@@ -15,13 +15,13 @@ package rest
 import (
 	"net/http"
 
-	"github.com/eclipse-che/che-machine-exec/activity"
 	"github.com/eclipse-che/che-machine-exec/auth"
 	restUtil "github.com/eclipse-che/che-machine-exec/common/rest"
+	"github.com/eclipse-che/che-machine-exec/timeout"
 	"github.com/gin-gonic/gin"
 )
 
-func HandleActivityTick(c *gin.Context, manager activity.Manager) {
+func HandleActivityTick(c *gin.Context, manager timeout.InactivityIdleManager) {
 	if auth.IsEnabled() {
 		_, err := auth.Authenticate(c)
 		if err != nil {

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -34,13 +34,13 @@ var (
 	AuthenticatedUserID string
 
 	// IdleTimeout is a inactivity period after which workspace should be stopped
-	// Default -1, which means - does not stop
+	// Default value is 30 minutes
 	IdleTimeout time.Duration
 	// StopRetryPeriod is a period after which workspace should be tried to stop if the previous try failed
-	// Defaults 10 second
+	// Default value is 10 seconds
 	StopRetryPeriod time.Duration
 	// RunTimeout is the maximum duration a workspace can be running before it is stopped
-	// Default -1, which means - no maximium duration
+	// Default value is -1, which means - no maximium duration
 	RunTimeout time.Duration
 
 	// UseTLS flag to enable/disable serving TLS
@@ -85,29 +85,31 @@ func init() {
 	}
 	flag.StringVar(&AuthenticatedUserID, "authenticated-user-id", defaultAuthenticatedUserID, "OpenShift user's ID that should has access to API. Is used only if useBearerToken is configured")
 
-	defaultIdleTimeout := -1 * time.Nanosecond
+	const defaultIdleTimeout = -1 * time.Nanosecond
+	idleTimeout := defaultIdleTimeout
 	idleTimeoutEnv := "SECONDS_OF_DW_INACTIVITY_BEFORE_IDLING"
 	idleTimeoutEnvValue, isFound := os.LookupEnv(idleTimeoutEnv)
 	if isFound && len(idleTimeoutEnvValue) > 0 {
-		if v, err := strconv.Atoi(idleTimeoutEnvValue); err == nil {
-			defaultIdleTimeout = time.Duration(v) * time.Second
+		if v, err := strconv.ParseInt(idleTimeoutEnvValue, 10, 32); err == nil {
+			idleTimeout = time.Duration(v) * time.Second
 		} else {
 			logrus.Errorf("Invalid value '%s' for env variable key '%s'. Value should be an integer", idleTimeoutEnvValue, idleTimeoutEnv)
 		}
 	}
-	flag.DurationVar(&IdleTimeout, "idle-timeout", defaultIdleTimeout, "IdleTimeout is a inactivity period after which workspace should be stopped. Examples: -1, 30s, 15m, 1h")
+	flag.DurationVar(&IdleTimeout, "idle-timeout", idleTimeout, "IdleTimeout is a inactivity period after which workspace should be stopped. By default, IdleTimeout is set to 30m. To disable IdleTimeout, set to -1. Examples: -1, 30s, 15m, 1h")
 
-	defaultRunTimeout := -1 * time.Nanosecond
+	const defaultRunTimeout = 1800 * time.Nanosecond
+	runtimeout := defaultRunTimeout
 	runTimeoutEnv := "SECONDS_OF_DW_RUN_BEFORE_IDLING"
 	runTimeoutEnvValue, isFound := os.LookupEnv(runTimeoutEnv)
 	if isFound && len(runTimeoutEnvValue) > 0 {
-		if v, err := strconv.Atoi(runTimeoutEnvValue); err == nil {
-			defaultRunTimeout = time.Duration(v) * time.Second
+		if v, err := strconv.ParseInt(runTimeoutEnvValue, 10, 32); err == nil {
+			runtimeout = time.Duration(v) * time.Second
 		} else {
 			logrus.Errorf("Invalid value '%s' for env variable key '%s'. Value should be an integer", runTimeoutEnvValue, runTimeoutEnv)
 		}
 	}
-	flag.DurationVar(&RunTimeout, "run-timeout", defaultRunTimeout, "RunTimeout is the maximum duration a workspace can run. After this period, the workspace will be stopped. Examples: -1, 30s, 15m, 1h")
+	flag.DurationVar(&RunTimeout, "run-timeout", runtimeout, "RunTimeout is the maximum duration a workspace can run. After this period, the workspace will be stopped. Examples: -1, 30s, 15m, 1h")
 
 	flag.DurationVar(&StopRetryPeriod, "stop-retry-period", 10*time.Second, "StopRetryPeriod is a period after which workspace should be tried to stop if the previous try failed. Examples: 30s")
 

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/eclipse-che/che-machine-exec/activity"
+	"github.com/eclipse-che/che-machine-exec/timeout"
 
 	jsonRpcApi "github.com/eclipse-che/che-machine-exec/api/jsonrpc"
 	"github.com/eclipse-che/che-machine-exec/api/rest"
@@ -30,9 +30,15 @@ func main() {
 	cfg.Parse()
 	cfg.Print()
 
-	activityManager, err := activity.New(cfg.IdleTimeout, cfg.StopRetryPeriod)
+	activityManager, err := timeout.NewInactivityIdleManager(cfg.IdleTimeout, cfg.StopRetryPeriod)
 	if err != nil {
 		logrus.Fatal("Unable to create activity manager. Cause: ", err.Error())
+		return
+	}
+
+	runtimeManager, err := timeout.NewRunIdleManager(cfg.RunTimeout, cfg.StopRetryPeriod)
+	if err != nil {
+		logrus.Fatal("Unable to create runtime manager. Cause: ", err.Error())
 		return
 	}
 
@@ -82,6 +88,10 @@ func main() {
 
 	if activityManager != nil {
 		activityManager.Start()
+	}
+
+	if runtimeManager != nil {
+		runtimeManager.Start()
 	}
 
 	if cfg.UseTLS {

--- a/timeout/run.go
+++ b/timeout/run.go
@@ -1,0 +1,99 @@
+//
+// Copyright (c) 2022 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package timeout
+
+import (
+	"errors"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/eclipse-che/che-machine-exec/exec"
+	"github.com/sirupsen/logrus"
+)
+
+type RunIdleManager interface {
+	// Start schedules workspace to stop after run timeout
+	// Should be called once
+	Start()
+}
+
+func NewRunIdleManager(runTimeout, stopRetryPeriod time.Duration) (RunIdleManager, error) {
+	if runTimeout <= 0 {
+		return &noOpRunIdleManager{}, nil
+	}
+
+	if stopRetryPeriod <= 0 {
+		return nil, errors.New("stop retry period must be greater than 0")
+	}
+
+	namespace := exec.GetNamespace()
+	if namespace == "" {
+		return nil, errors.New("unable to evaluate the current namespace required for run idle manager to work correctly")
+	}
+
+	workspaceName, isFound := os.LookupEnv("CHE_WORKSPACE_NAME")
+	if !isFound {
+		workspaceName, isFound = os.LookupEnv("DEVWORKSPACE_NAME")
+		if !isFound {
+			return nil, errors.New("CHE_WORKSPACE_NAME or DEVWORKSPACE_NAME environment variables must be set for activity manager to work correctly")
+		}
+	}
+
+	return runIdleManagerImpl{
+		namespace:       namespace,
+		workspaceName:   workspaceName,
+		runTimeout:      runTimeout,
+		stopRetryPeriod: stopRetryPeriod,
+	}, nil
+}
+
+// noOpRunIdleManager should be used if run timeout is configured less 0
+// invocation its method does not have affect
+type noOpRunIdleManager struct{}
+
+func (m noOpRunIdleManager) Start() {}
+
+type runIdleManagerImpl struct {
+	namespace     string
+	workspaceName string
+
+	runTimeout      time.Duration
+	stopRetryPeriod time.Duration
+}
+
+func (m runIdleManagerImpl) Start() {
+	logrus.Infof("Run idle manager is running. The workspace will be stopped in %s", m.runTimeout)
+	timer := time.NewTimer(m.runTimeout)
+	var shutdownChan = make(chan os.Signal, 1)
+	signal.Notify(shutdownChan, syscall.SIGTERM)
+
+	go func() {
+		for {
+			select {
+			case <-timer.C:
+				if err := stopWorkspace(m.namespace, m.workspaceName); err != nil {
+					timer.Reset(m.stopRetryPeriod)
+					logrus.Errorf("Failed to stop workspace. Will retry in %s. Cause: %s", m.stopRetryPeriod, err)
+				} else {
+					logrus.Info("Workspace has reached its run timeout. Bye")
+					return
+				}
+			case <-shutdownChan:
+				logrus.Info("Received SIGTERM: shutting down run timeout manager")
+				return
+			}
+		}
+	}()
+}

--- a/timeout/shutdown.go
+++ b/timeout/shutdown.go
@@ -1,0 +1,77 @@
+//
+// Copyright (c) 2022 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package timeout
+
+import (
+	"context"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+var (
+	DevWorkspaceGroupVersion = &schema.GroupVersion{
+		Group:   "workspace.devfile.io",
+		Version: "v1alpha1",
+	}
+)
+
+func stopWorkspace(namespace string, workspaceName string) error {
+	c, err := newWorkspaceClientInCluster()
+	if err != nil {
+		return err
+	}
+
+	stopWorkspacePath := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": map[string]interface{}{
+					"controller.devfile.io/stopped-by": "inactivity",
+				},
+			},
+			"spec": map[string]interface{}{
+				"started": false,
+			},
+		},
+	}
+	jsonPath, err := stopWorkspacePath.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	_, err = c.Resource(DevWorkspaceGroupVersion.WithResource("devworkspaces")).Namespace(namespace).Patch(context.TODO(), workspaceName, types.MergePatchType, jsonPath, v1.PatchOptions{}, "")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func newWorkspaceClientInCluster() (dynamic.Interface, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	config.APIPath = "/apis"
+	config.GroupVersion = DevWorkspaceGroupVersion
+
+	c, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

Part of https://github.com/eclipse/che/issues/21390

This PR introduces two features:

1. reads the following environment variables set the activity idling timeout and run timeout respectively:
     - `SECONDS_OF_DW_INACTIVITY_BEFORE_IDLING`:  the number of seconds after which a workspace is stopped if there is no user activity (in other words, no requests to machine-exec's `/activity/tick` endpoint)
     - `SECONDS_OF_DW_RUN_BEFORE_IDLING`: the number of seconds after which a workspace is stopped, regardless of user activity. This feature is synonymous to [CHE_LIMITS_WORKSPACE_RUN_TIMEOUT](https://www.eclipse.org/che/docs/che-7/installation-guide/advanced-configuration-options-for-the-che-server-component/#_che_limits_workspace_run_timeout) from the che-server config.

    These timeouts can be provided to che-machine-exec by using optional flags `--idle-timeout` and `--run-timeout`. If these flags are provided AND the env variables above are set, the flags will take precedence.
     
2. implements the functionality for `SECONDS_OF_DW_RUN_BEFORE_IDLING` via [RunIdleManager](https://github.com/eclipse-che/che-machine-exec/blob/73fb5cf7012c3f135a7107bc847a16859c2d6896/timeout/run.go#L26)

This PR also renamed the `activity` package to `timeout`, since the run timeout feature will shut down workspaces regardless of user activity. Files under this package have also been renamed.

### To test this PR:
1. Prepare a cluster with Che + devworkspace engine
2. Create the following configmap in your user namespace to mount the timeout environment variables to workspace containers:
```
kind: ConfigMap
apiVersion: v1
metadata:
  name: idle-settings
  labels:
    controller.devfile.io/mount-to-devworkspace: 'true'
    controller.devfile.io/watch-configmap: 'true'
  annotations:
    controller.devfile.io/mount-as: env
data:
  SECONDS_OF_DW_INACTIVITY_BEFORE_IDLING: '180'
  SECONDS_OF_DW_RUN_BEFORE_IDLING: '300'
```
In the configmap, the inactivity timeout is set at 3 minutes (= 180 seconds) while the run timeout is set at 5 minutes (= 300 seconds)

3. Create a workspace with the following che-code [devfilev2](https://gist.githubusercontent.com/dkwon17/7e614065c40c71b62436b31e358fc9f4/raw/f16938add515802665f76d919687d93aef6b1cc8/gistfile1.txt)

For example, to create a golang che sample workspace with the above editor, go to:
```
{CHE_HOST}/#https://github.com/che-samples/golang-example/tree/devfilev2?che-editor=https://gist.githubusercontent.com/dkwon17/7e614065c40c71b62436b31e358fc9f4/raw/f16938add515802665f76d919687d93aef6b1cc8/gistfile1.txt
```

The che-code image in the devfile v2 above contains the che-machine-exec binary created with this PR. 

4. When the workspace is running, view the logs in the `tools` container of the workspace pod. You should see the following output:
```
time="2022-07-07T20:48:38Z" level=info msg="==> Idle timeout: 3m0s"
time="2022-07-07T20:48:38Z" level=info msg="==> Run timeout: 5m0s"
```

5. Check that the workspace is shut down correctly:
* To check the idle timeout, start the workspace. After 3 minutes, the `tools` container should log `msg="Workspace is successfully stopped by inactivity. Bye"` and the workspace should terminate.
* To check the run timeout, change `SECONDS_OF_DW_RUN_BEFORE_IDLING` to a value smaller than `SECONDS_OF_DW_INACTIVITY_BEFORE_IDLING`. Start the workspace. Eventually the `tools` container should log `msg="Workspace has reached its run timeout. Bye"` and the workspace should terminate.