### PR TITLE
Small fixes for workspace timeouts

### DIFF
--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -85,7 +85,7 @@ func init() {
 	}
 	flag.StringVar(&AuthenticatedUserID, "authenticated-user-id", defaultAuthenticatedUserID, "OpenShift user's ID that should has access to API. Is used only if useBearerToken is configured")
 
-	const defaultIdleTimeout = -1 * time.Nanosecond
+	const defaultIdleTimeout = 1800 * time.Second
 	idleTimeout := defaultIdleTimeout
 	idleTimeoutEnv := "SECONDS_OF_DW_INACTIVITY_BEFORE_IDLING"
 	idleTimeoutEnvValue, isFound := os.LookupEnv(idleTimeoutEnv)
@@ -98,7 +98,7 @@ func init() {
 	}
 	flag.DurationVar(&IdleTimeout, "idle-timeout", idleTimeout, "IdleTimeout is a inactivity period after which workspace should be stopped. By default, IdleTimeout is set to 30m. To disable IdleTimeout, set to -1. Examples: -1, 30s, 15m, 1h")
 
-	const defaultRunTimeout = 1800 * time.Nanosecond
+	const defaultRunTimeout = -1 * time.Nanosecond
 	runtimeout := defaultRunTimeout
 	runTimeoutEnv := "SECONDS_OF_DW_RUN_BEFORE_IDLING"
 	runTimeoutEnvValue, isFound := os.LookupEnv(runTimeoutEnv)

--- a/timeout/inactivity.go
+++ b/timeout/inactivity.go
@@ -99,7 +99,7 @@ func (m inactivityIdleManagerImpl) Start() {
 		for {
 			select {
 			case <-timer.C:
-				if err := stopWorkspace(m.namespace, m.workspaceName); err != nil {
+				if err := stopWorkspace(m.namespace, m.workspaceName, stoppedByInactivity); err != nil {
 					timer.Reset(m.stopRetryPeriod)
 					logrus.Errorf("Failed to stop workspace. Will retry in %s. Cause: %s", m.stopRetryPeriod, err)
 				} else {

--- a/timeout/run.go
+++ b/timeout/run.go
@@ -83,7 +83,7 @@ func (m runIdleManagerImpl) Start() {
 		for {
 			select {
 			case <-timer.C:
-				if err := stopWorkspace(m.namespace, m.workspaceName); err != nil {
+				if err := stopWorkspace(m.namespace, m.workspaceName, stoppedByRunTimeout); err != nil {
 					timer.Reset(m.stopRetryPeriod)
 					logrus.Errorf("Failed to stop workspace. Will retry in %s. Cause: %s", m.stopRetryPeriod, err)
 				} else {

--- a/timeout/shutdown.go
+++ b/timeout/shutdown.go
@@ -26,11 +26,16 @@ import (
 var (
 	DevWorkspaceGroupVersion = &schema.GroupVersion{
 		Group:   "workspace.devfile.io",
-		Version: "v1alpha1",
+		Version: "v1alpha2",
 	}
 )
 
-func stopWorkspace(namespace string, workspaceName string) error {
+const (
+	stoppedByInactivity = "inactivity"
+	stoppedByRunTimeout = "run-timeout"
+)
+
+func stopWorkspace(namespace string, workspaceName string, reason string) error {
 	c, err := newWorkspaceClientInCluster()
 	if err != nil {
 		return err
@@ -40,7 +45,7 @@ func stopWorkspace(namespace string, workspaceName string) error {
 		Object: map[string]interface{}{
 			"metadata": map[string]interface{}{
 				"annotations": map[string]interface{}{
-					"controller.devfile.io/stopped-by": "inactivity",
+					"controller.devfile.io/stopped-by": reason,
 				},
 			},
 			"spec": map[string]interface{}{


### PR DESCRIPTION
This PR introduces two fixes for the workspace timeouts:
1. Fix the default timeouts that were incorrectly set in: https://github.com/eclipse-che/che-machine-exec/pull/208
2. The `"controller.devfile.io/stopped-by"` annotation was always set to `"inactivity"` when machine-exec stopped a workspace regardless if it was a run timeout or an idle (inactivity) timeout. In this PR, `"controller.devfile.io/stopped-by"` is set to `"run-timeout"` if the workspace has been stopped due to run timeout.