### PR TITLE
fix: update DevWorkspace group version

### DIFF
--- a/timeout/shutdown.go
+++ b/timeout/shutdown.go
@@ -26,7 +26,7 @@ import (
 var (
 	DevWorkspaceGroupVersion = &schema.GroupVersion{
 		Group:   "workspace.devfile.io",
-		Version: "v1alpha1",
+		Version: "v1alpha2",
 	}
 )
 


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

Fixes https://github.com/eclipse/che/issues/21549#issuecomment-1185967059

To test this PR:

1. In the CheCluster CR, set `spec.devEnvironments.secondsOfRunBeforeIdling` to `30`

2. Create a workspace with the following factory url:
```
{CHE-HOST}/#https://github.com/che-samples/golang-example/tree/devfilev2?che-editor=https://gist.githubusercontent.com/dkwon17/ca3129222898f8f65ef5a9cd5a6945fb/raw/758a9dcd578d5d5b96e532a764290b40ff257ffa/checode-v1alpha2
```

3. Wait until the workspace pod terminates due to the run timeout set at step 1.

4. Verify that `spec.template.attributes` of the devworkspace was not cleared.