### PR TITLE
Chore: CRW-4043 adding brew.Dockerfile and readme explaining Dockerfiles

### DIFF
--- a/build/dockerfiles/README.md
+++ b/build/dockerfiles/README.md
@@ -1,7 +1,7 @@
 # Dockerfile Clarification
 
-**Dockerfile** is the Eclipse Che build file, intended to be used from the [eclipse-che/che-machine-exec](https://github.com/eclipse-che/che-machine-exec) repo.
+**Dockerfile** is the Eclipse Che build file, used in this repo to publish to [quay.io/eclipse/che-machine-exec](https://quay.io/repository/eclipse/che-machine-exec?tab=tags).
 
-**rhel.Dockerfile** is the build file for the [Red Hat OpenShift Devspaces](https://github.com/redhat-developer/devspaces-images/tree/devspaces-3-rhel-8/devspaces-machineexec) image.
+**rhel.Dockerfile** is the build file for the [Red Hat OpenShift Devspaces](https://github.com/redhat-developer/devspaces-images/tree/devspaces-3-rhel-8/devspaces-machineexec) image, which can be run locally.
 
-**brew.Dockerfile** is specifically for Red Hat internal brew builds and will be generally unusably otherwise.
+**brew.Dockerfile** is a variation on `rhel.Dockerfile` specifically for Red Hat builds, and cannot be run locally as is.

--- a/build/dockerfiles/README.md
+++ b/build/dockerfiles/README.md
@@ -1,0 +1,7 @@
+# Dockerfile Clarification
+
+**Dockerfile** is the Eclipse Che build file, intended to be used from the [eclipse-che/che-machine-exec](https://github.com/eclipse-che/che-machine-exec) repo.
+
+**rhel.Dockerfile** is the build file for the [Red Hat OpenShift Devspaces](https://github.com/redhat-developer/devspaces-images/tree/devspaces-3-rhel-8/devspaces-machineexec) image.
+
+**brew.Dockerfile** is specifically for Red Hat internal brew builds and will be generally unusably otherwise.

--- a/build/dockerfiles/brew.Dockerfile
+++ b/build/dockerfiles/brew.Dockerfile
@@ -1,0 +1,32 @@
+# Copyright (c) 2019-2023 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+# https://registry.access.redhat.com/rhel8/go-toolset
+FROM rhel8/go-toolset:1.18.9-13 as builder
+ENV GOPATH=/go/
+USER root
+WORKDIR /che-machine-exec/
+COPY . .
+RUN adduser unprivilegeduser && \
+    CGO_ENABLED=0 GOOS=linux go build -mod=vendor -a -ldflags '-w -s' -a -installsuffix cgo -o che-machine-exec . && \
+    mkdir -p /rootfs/tmp /rootfs/etc /rootfs/go/bin && \
+    # In the `scratch` you can't use Dockerfile#RUN, because there is no shell and no standard commands (mkdir and so on).
+    # That's why prepare absent `/tmp` folder for scratch image
+    chmod 1777 /rootfs/tmp && \
+    cp -rf /etc/passwd /rootfs/etc && \
+    cp -rf /che-machine-exec/che-machine-exec /rootfs/go/bin
+
+FROM scratch
+COPY --from=builder /rootfs /
+USER unprivilegeduser
+ENTRYPOINT ["/go/bin/che-machine-exec"]
+
+# append Brew metadata here


### PR DESCRIPTION
The README is mostly so people know not to try to use brew.Dockerfile.