### PR TITLE
Changes for CRW-4552, CRW-4502 and CRW-3890

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -12,7 +12,7 @@
 # Dockerfile defines che-machine-exec production image eclipse/che-machine-exec-dev
 #
 
-FROM docker.io/golang:1.18-alpine as go_builder
+FROM docker.io/golang:1.19.13-alpine as go_builder
 
 ENV USER=machine-exec
 ENV UID=12345

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/eclipse-che/che-machine-exec
 
-go 1.18
+go 1.19
 
 replace (
 	cloud.google.com/go => cloud.google.com/go v0.54.0
@@ -168,7 +168,7 @@ replace (
 
 require (
 	github.com/eclipse/che-go-jsonrpc v0.0.0-20200317130110-931966b891fe
-	github.com/gin-gonic/gin v1.8.2
+	github.com/gin-gonic/gin v1.9.1
 	github.com/gorilla/websocket v1.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9,7 +9,7 @@ github.com/eclipse/che-go-jsonrpc/jsonrpcws
 # github.com/gin-contrib/sse v0.1.0 => github.com/gin-contrib/sse v0.0.0-20170109093832-22d885f9ecc7
 ## explicit
 github.com/gin-contrib/sse
-# github.com/gin-gonic/gin v1.8.2 => github.com/gin-gonic/gin v1.8.2
+# github.com/gin-gonic/gin v1.9.1 => github.com/gin-gonic/gin v1.8.2
 ## explicit; go 1.18
 github.com/gin-gonic/gin
 github.com/gin-gonic/gin/binding


### PR DESCRIPTION
[CRW-4552](https://issues.redhat.com/browse/CRW-4552) - update github.com/gin-gonic/gin to 1.9.1 (also resolves [CRW-4502](https://issues.redhat.com/browse/CRW-4502))

[CRW-3890](https://issues.redhat.com/browse/CRW-3890) - was resolved by updating brew.Dockerfile to go-toolset:1.19.13, but this made downstream no longer consistent so I updated Dockerfile to use golang:1.19.13-alpine and updated go to 1.19 in go.mod.