### PR TITLE
fix: che-22646 use gh instead of hub

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -130,9 +130,6 @@ if [[ ${NOCOMMIT} -eq 0 ]]; then
     git checkout "${PR_BRANCH}"
     git pull origin "${PR_BRANCH}"
     git push origin "${PR_BRANCH}"
-    lastCommitComment="$(git log -1 --pretty=%B)"
-    hub pull-request -f -m "${lastCommitComment}
-
-${lastCommitComment}" -b "${BRANCH}" -h "${PR_BRANCH}"
+    gh pr create -f -B "${BRANCH}" -H "${PR_BRANCH}"
   fi
 fi


### PR DESCRIPTION
Use `gh` tool instead of `hub` tool, that was removed from the workflow runner

related to  https://github.com/eclipse/che/issues/22646