### PR TITLE
Use initial terminal size when creating a terminal

### DIFF
--- a/exec/kubernetes_exec_manager.go
+++ b/exec/kubernetes_exec_manager.go
@@ -236,10 +236,12 @@ func (manager *KubernetesExecManager) doCreate(machineExec *model.MachineExec, c
 	machineExec.Executor = executor
 	machineExec.ID = int(atomic.AddUint64(&prevExecID, 1))
 	machineExec.MsgChan = make(chan []byte)
-	machineExec.SizeChan = make(chan remotecommand.TerminalSize)
+	machineExec.SizeChan = make(chan remotecommand.TerminalSize, 1)
 	machineExec.ExitChan = make(chan bool)
 	machineExec.ErrorChan = make(chan error)
 	machineExec.ConnectionHandler = ws.NewConnHandler()
+
+	machineExec.SizeChan <- remotecommand.TerminalSize{Width: uint16(machineExec.Cols), Height: uint16(machineExec.Rows)}
 
 	execs.execMap[machineExec.ID] = machineExec
 


### PR DESCRIPTION
### Description

When creating a new terminal, queue the initial number of rows/columns in the resize channel after starting to ensure the terminal uses the correct initial size (this requires making the channel buffered).

This _should_ fix https://github.com/eclipse/che/issues/22584, except when testing it in the Code editor, the `initialDimensions` sent to machine-exec are wrong -- resizing the terminal pane by even a few pixels shows the new computed size is 7-9 characters wider.

### How to test
These changes are built into `quay.io/amisevsk/che-code:terminal-size` (with some additional logging to allow debugging terminal size issues). 

To test these changes:
1. Start a Che workspace
2. In the Code terminal, run the following command to change the che-code image: 
    ```
    oc get dwt che-code-$DEVWORKSPACE_NAME -o yaml | sed 's|quay.io/che-incubator/che-code.*|quay.io/amisevsk/che-code:terminal-size|' | oc apply -f -
    ```
3. Restart the workspace (e.g. using F1 -> restart workspace)
4. Verify terminal width and height are set correctly in new terminals created via "New terminal (Select a container)" -- text should wrap as normal (see linked issue for the original bug)