### PR TITLE
Update GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Set up Go 1.25
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.25.7
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Submit code coverage results

--- a/.github/workflows/dependencies-md-check.yaml
+++ b/.github/workflows/dependencies-md-check.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     - name: DEPENDENCIES.md file validator.
       uses: che-incubator/dependencies-license-action@0.0.2
       env:

--- a/.github/workflows/gh_actions_pr.yaml
+++ b/.github/workflows/gh_actions_pr.yaml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout che-machine-exec source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v4
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v4
     - name: Check docker build
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v7
       with:
         file: build/dockerfiles/Dockerfile
         platforms: linux/amd64,linux/arm64

--- a/.github/workflows/gh_actions_unit.yaml
+++ b/.github/workflows/gh_actions_unit.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout che-machine-exec source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     - name: Build che-machine-exec binary
       run: CGO_ENABLED=0 GOOS=linux go build -mod=vendor -a -ldflags '-w -s' -a -installsuffix cgo -o che-machine-exec .
     - name: Run unit tests

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Set up Go 1.25
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.25.7
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Check Eclipse license headers
         run: |
           go install github.com/che-incubator/check-license-header@379ba18fdb906d341ae451ea155cc34f1c4b4f1a

--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -22,13 +22,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout che-machine-exec source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v4
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v4
     - name: Login to quay.io
-      uses: docker/login-action@v2
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
@@ -37,7 +37,7 @@ jobs:
       shell: bash
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
     - name: Build and push both short SHA tag and next tag
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v7
       with:
         file: build/dockerfiles/Dockerfile
         platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check existing tags
@@ -53,21 +53,21 @@ jobs:
             echo "[INFO] No existing tags detected for $VERSION"
           fi
       - name: Login to docker.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           registry: docker.io
       - name: Login to quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
           registry: quay.io
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Create Release
         run: |
           git config --global user.name "Mykhailo Kuznietsov"

--- a/.github/workflows/try-in-web-ide.yaml
+++ b/.github/workflows/try-in-web-ide.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Web IDE Pull Request Check
-        uses: redhat-actions/try-in-web-ide@v1
+        uses: redhat-actions/try-in-web-ide@v1.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           add_comment: false


### PR DESCRIPTION
GitHub is deprecating Node 20 on Actions runners (June 16, 2026). Upgrade all action versions to their Node 24-compatible releases:
- actions/checkout v3 → v6
- actions/setup-go v3 → v5
- docker/setup-qemu-action v2 → v4
- docker/setup-buildx-action v2 → v4
- docker/build-push-action v3 → v7
- docker/login-action v2 → v4
- redhat-actions/try-in-web-ide v1 → v1.4

see https://github.com/eclipse-che/che/issues/23861