### PR TITLE
chore: Remove Travis CI build step from workflow

### DIFF
--- a/.github/workflows/gh_actions_pr.yaml
+++ b/.github/workflows/gh_actions_pr.yaml
@@ -30,28 +30,3 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: false
         tags: quay.io/eclipse/che-machine-exec:pr-check
-
-  travis-build:
-    runs-on: ubuntu-22.04
-    continue-on-error: true
-    steps:
-    - name: Trigger build on Travis CI
-      run: |
-        body="{
-        \"request\":{
-        \"config\": {
-          \"env\": {
-            \"global\": [
-              \"PR_NUMBER=${{ github.event.pull_request.number }}\"
-             ]
-           }
-        }
-        }}"
-
-        curl -s -X POST \
-        -H "Content-Type: application/json" \
-        -H "Accept: application/json" \
-        -H "Travis-API-Version: 3" \
-        -H "Authorization: token ${{ secrets.TRAVIS_TOKEN }}" \
-        -d "$body" \
-        https://api.travis-ci.com/repo/eclipse-che%2Fche-machine-exec/requests


### PR DESCRIPTION
Removed Travis CI build step from GitHub Actions workflow. Removed from a while now.