### PR TITLE
feat: Support running machine-exec in ubi-based containers

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -12,6 +12,41 @@
 # Dockerfile defines che-machine-exec production image eclipse/che-machine-exec-dev
 #
 
+#########################################################################
+############################# BUILD: ubi8-machine-exec ##################
+#########################################################################
+
+FROM registry.access.redhat.com/ubi8/go-toolset:1782923914 AS ubi8-machineexec-builder
+ENV GOPATH=/go/
+ENV CGO_ENABLED=1
+USER root
+
+WORKDIR /che-machine-exec/
+COPY . .
+
+RUN GOOS=linux go build -mod=vendor -ldflags '-w -s' -a -installsuffix cgo -o che-machine-exec . \
+    && mkdir -p /rootfs/go/bin \
+    && cp -rf /che-machine-exec/che-machine-exec /rootfs/go/bin
+
+#########################################################################
+############################# BUILD: ubi9-machine-exec ##################
+#########################################################################
+
+FROM registry.access.redhat.com/ubi9/go-toolset:9.8-1783442369 AS ubi9-machineexec-builder
+ENV GOPATH=/go/
+ENV CGO_ENABLED=1
+USER root
+
+WORKDIR /che-machine-exec/
+COPY . .
+
+RUN GOOS=linux go build -mod=vendor -ldflags '-w -s' -a -installsuffix cgo -o che-machine-exec . \
+    && mkdir -p /rootfs/go/bin \
+    && cp -rf /che-machine-exec/che-machine-exec /rootfs/go/bin
+
+#########################################################################
+############################# BUILD: alpine-machine-exec ################
+#########################################################################
 FROM docker.io/golang:1.25.7-alpine as go_builder
 
 ENV USER=machine-exec
@@ -59,6 +94,8 @@ COPY --from=go_builder /etc/passwd /etc/passwd
 COPY --from=go_builder /etc/group /etc/group
 USER machine-exec
 
-COPY --from=go_builder /go/bin/che-machine-exec /go/bin/che-machine-exec
+COPY --from=ubi8-machineexec-builder --chown=0:0 /rootfs/go/bin/che-machine-exec /go/ubi8/bin/che-machine-exec
+COPY --from=ubi9-machineexec-builder --chown=0:0 /rootfs/go/bin/che-machine-exec /go/ubi9/bin/che-machine-exec
+COPY --from=go_builder --chown=0:0 /go/bin/che-machine-exec /go/bin/che-machine-exec
 COPY --from=cloud_shell_builder /app /cloud-shell
 ENTRYPOINT ["/go/bin/che-machine-exec", "--static", "/cloud-shell"]


### PR DESCRIPTION
### What does this PR do?
The che-machine-exec image now ships platform-specific binaries for UBI 8, UBI 9, and Alpine (musl), enabling FIPS-compliant execution in glibc-based containers.

Previously the image contained only a single Alpine/musl binary. While it worked in UBI containers (as a static build), it bypassed the host's crypto stack. Now each binary is built natively with CGO_ENABLED=1 against the target platform's glibc, ensuring proper FIPS compliance.

The final image layout:

- `/go/bin/che-machine-exec` — Alpine/musl (default entrypoint, backward-compatible)
- `/go/ubi8/bin/che-machine-exec` — UBI 8 (glibc, OpenSSL 1.x)
- `/go/ubi9/bin/che-machine-exec` — UBI 9 (glibc, OpenSSL 3.x)

Consumers (e.g. che-code's assembly.Dockerfile) can now COPY the appropriate binary into each `checode` assembly directory, so `entrypoint-volume.sh` picks the correct one at runtime based on the detected platform.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
- https://github.com/eclipse-che/che/issues/23648
- https://redhat.atlassian.net/browse/CRW-11626

### How to test this PR?
Create `machine-exec` terminal using `Terminal` => `New Terminal (Select a Container)`
<img width="842" height="317" alt="Screenshot 2026-07-08 at 18 34 52" src="https://github.com/user-attachments/assets/8e0b1a3e-d197-464f-be5d-5de693653c5b" />

I've built image with current PR changes and applied it for the `che-code` editor: https://github.com/che-incubator/che-code/pull/748

I used the following links to start a workspace and test `machine-exec`:
- [ubi8-minimal:latest](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample?new&image=registry.access.redhat.com/ubi8-minimal:latest&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-748-amd64)
- [ubi9-minimal:latest](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample?new&image=registry.access.redhat.com/ubi9-minimal:latest&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-748-amd64)
- [ubi10-minimal:latest](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample?new&image=registry.access.redhat.com/ubi10-minimal:latest&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-748-amd64)
- [node:22-alpine3.22](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample?new&image=docker.io/node:22-alpine3.22&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-748-amd64)

